### PR TITLE
server build fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7902,7 +7902,7 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/node": "^25.0.1",
-        "@types/uuid": "^9.0.7",
+        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
         "eslint": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "concurrently \"npm run dev -w server\" \"npm run dev -w client\"",
     "dev:server": "npm run dev -w server",
     "dev:client": "npm run dev -w client",
-    "start:server": "node server/dist/index.js",
+    "start:server": "node server/dist/server/src/index.js",
     "install-all": "npm install"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc -p .",
-    "start": "node dist/index.js",
+    "start": "node dist/server/src/index.js",
     "lint": "eslint --ext .ts src",
     "format": "prettier --write \"src/**/*.{ts,md}\""
   },
@@ -17,10 +17,10 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@types/uuid": "^9.0.7",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/node": "^25.0.1",
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "eslint": "^8.57.0",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "CommonJS",
     "moduleResolution": "Node",
     "outDir": "dist",
+    "rootDir": "..",
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
@@ -13,6 +14,6 @@
       "@shared/*": ["../../shared/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../shared/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/shared/types.js
+++ b/shared/types.js
@@ -1,0 +1,6 @@
+export const TEAM_FOR_SEAT = {
+    0: 0,
+    1: 1,
+    2: 0,
+    3: 1,
+};


### PR DESCRIPTION
This pull request primarily updates build and start script paths, adjusts TypeScript configuration for the server, and introduces a new shared constant. The most important changes are grouped below.

**Build and Start Script Updates:**

* Changed the `start:server` and `start` scripts in both the root `package.json` and `server/package.json` to point to `server/dist/server/src/index.js` instead of `server/dist/index.js`, ensuring the correct entry point is used after build. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R20) [[2]](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37L9-R9)

**TypeScript Configuration Improvements:**

* Updated `server/tsconfig.json` to set `rootDir` to `..` and include `../shared/**/*.ts` in the compilation, allowing shared code to be included in the server build. [[1]](diffhunk://#diff-f3eab147f9c67d8aeb9f4f641a6b199d8b9eebae738083ea2f9a4a79aaca0175R7) [[2]](diffhunk://#diff-f3eab147f9c67d8aeb9f4f641a6b199d8b9eebae738083ea2f9a4a79aaca0175L16-R17)

**Dependency Version Update:**

* Bumped `@types/uuid` devDependency in `server/package.json` from version `^9.0.7` to `^9.0.8`.

**New Shared Constant:**

* Added a new `TEAM_FOR_SEAT` constant to `shared/types.js` for mapping seat numbers to team numbers.