### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,6 @@
 name: Chkobba CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/MohamedRayeneRomdhane/chkobba/security/code-scanning/1](https://github.com/MohamedRayeneRomdhane/chkobba/security/code-scanning/1)

The recommended fix is to explicitly limit the permissions granted to the `GITHUB_TOKEN` in the workflow. Since none of the jobs in the workflow require write access to the repository (they do not, for example, push code, create releases, or interact with issues or pull requests), the minimum necessary permission is `contents: read`, which allows jobs only to download repository code and read basic metadata. The best practice is to define `permissions: contents: read` at the top level of the workflow file (just below `name`), which applies to all jobs. This does not change any existing behavior but narrows potential attack surface and follows GitHub's security guidance.

You only need to insert the following lines after the `name:` line and before `on:`:
```yaml
permissions:
  contents: read
```
No further edits to jobs or steps are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
