### PR TITLE
fixed bug where end screen stays always on top

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -118,8 +118,12 @@ export default function App() {
           </>
         }
       >
-        {/* End screen overlay: show during round end or until all replay votes */}
-        {(lastRound || (replayWaiting && replayWaiting.count < replayWaiting.total)) && (
+        {/* End screen overlay: show after round end and until all replays */}
+        {(() => {
+          const waitingForReplay = replayWaiting ? replayWaiting.count < replayWaiting.total : true; // if replayWaiting not loaded yet, keep overlay visible after end
+          const shouldShowOverlay = !!lastRound && waitingForReplay;
+          return shouldShowOverlay;
+        })() && (
           <EndOverlay
             banner={roundBanner}
             scores={lastRound?.scores ?? gameState?.scoresByTeam ?? null}


### PR DESCRIPTION
This pull request updates the logic for displaying the end screen overlay in the `App` component to ensure it appears only after the round has ended and remains until all replay votes are received. The new approach also handles cases where replay data hasn't loaded yet, keeping the overlay visible as needed.

**User interface logic improvements:**

* Updated the overlay display logic in `App.tsx` to show the end screen only after the round ends and while waiting for all replays, including cases where replay data is still loading.