### PR TITLE
privacy update

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,11 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/x-icon" href="/assets/icons/icon.ico" />
     <link rel="shortcut icon" type="image/x-icon" href="/assets/icons/icon.ico" />
-    <script
-      async
-      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9124857144736473"
-      crossorigin="anonymous"
-    ></script>
     <meta
       name="description"
       content="Chkobba Café — a fast, friendly online chkobba card game with a cozy café feel. Create a room, invite friends, and play."

--- a/client/src/components/LegalModal.tsx
+++ b/client/src/components/LegalModal.tsx
@@ -69,6 +69,18 @@ export default function LegalModal({ open, section, onClose }: Props) {
                   collect information to personalize or measure ads. If you decline, ads won’t be
                   loaded.
                 </p>
+                <p className="mt-2 text-gray-700">
+                  Learn more:
+                  <a
+                    href="https://policies.google.com/technologies/partner-sites"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline ml-1"
+                  >
+                    How Google uses data
+                  </a>
+                  .
+                </p>
               </div>
 
               <div>

--- a/client/src/hooks/useCookieConsent.ts
+++ b/client/src/hooks/useCookieConsent.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export type CookieConsentStatus = 'granted' | 'denied' | null;
 
@@ -12,11 +12,7 @@ function readStoredConsent(): CookieConsentStatus {
 }
 
 export function useCookieConsent() {
-  const [status, setStatus] = useState<CookieConsentStatus>(null);
-
-  useEffect(() => {
-    setStatus(readStoredConsent());
-  }, []);
+  const [status, setStatus] = useState<CookieConsentStatus>(() => readStoredConsent());
 
   const accept = useCallback(() => {
     window.localStorage.setItem(STORAGE_KEY, 'granted');


### PR DESCRIPTION
This pull request focuses on privacy improvements and minor UI enhancements related to cookie consent and advertising scripts. The main changes remove the Google Ads script from the site, update the cookie consent logic for better reliability, and add an informational link about Google’s data usage in the legal modal.

**Privacy and advertising:**
* Removed the Google Ads script from `client/index.html`, eliminating third-party ad loading and associated tracking.

**Cookie consent logic:**
* Updated the `useCookieConsent` hook to initialize consent status directly from local storage, removing the unnecessary `useEffect` for improved reliability and performance. [[1]](diffhunk://#diff-d0b7c0dc9cee996a2ab0222c0ee91234d8a6d1ff48c96293f4c35eded0e1e1c0L1-R1) [[2]](diffhunk://#diff-d0b7c0dc9cee996a2ab0222c0ee91234d8a6d1ff48c96293f4c35eded0e1e1c0L15-R15)

**Legal modal UI:**
* Added a link to Google’s partner site data usage policy in the legal modal for greater transparency about data usage.